### PR TITLE
Add required flag for execution

### DIFF
--- a/games-fps/gzdoom/gzdoom-9999.ebuild
+++ b/games-fps/gzdoom/gzdoom-9999.ebuild
@@ -13,7 +13,7 @@ EGIT_REPO_URI="https://github.com/coelckers/gzdoom.git"
 LICENSE="DOOMLIC BUILDLIC BSD"
 SLOT="0"
 KEYWORDS=""
-IUSE="cpu_flags_x86_mmx +gtk +fluidsynth +soundfont"
+IUSE="cpu_flags_x86_mmx +gtk +fluidsynth +soundfont +opengl"
 
 DEPEND="
 		soundfont? (


### PR DESCRIPTION
If libsdl2 isn't compiled with the opengl USE flag, gzdoom won't be able to start.